### PR TITLE
jdk17, kubectl + base image update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bloop
 .metals
 .terraform
+.vscode/
 *.pem
 app.*.log.gz
 *.tfstate*

--- a/aws.nix
+++ b/aws.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
     };

--- a/aws.nix
+++ b/aws.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2020-05-08";
-        # Commit hash for nixos-unstable as of 2020-05-08 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/d78ba41a5604c8e06d40756a2436e52169354d36.tar.gz;
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "0bk81ddx1iq8i0nhg1i44kllihphyzhbc416zgylli0ycphknrkv";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
     };

--- a/gcp.nix
+++ b/gcp.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
     };
@@ -22,6 +22,7 @@ in
       gcptools
       pkgs.kubernetes-helm
       pkgs.kubectl
+      pkgs.kubectx
     ];
 
     shellHook = ''

--- a/gcp.nix
+++ b/gcp.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-01-27";
-        # Commit hash for nixos-unstable as of 2021-01-27 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/891f607d5301d6730cb1f9dcf3618bcb1ab7f10e.tar.gz;
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1cr39f0sbr0h5d83dv1q34mcpwnkwwbdk5fqlyqp2mnxghzwssng";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
     };

--- a/haskell.nix
+++ b/haskell.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2020-05-08";
-        # Commit hash for nixos-unstable as of 2020-08-05 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/aa7efea848f5f936a86ea3c4dcd582df0b57699d.tar.gz;
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "16wzghfxl9a4lvmvhxy6vgkdvb3b77dr9avbzzgfgxp2bcafbavb";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
     };

--- a/nodejs.nix
+++ b/nodejs.nix
@@ -4,11 +4,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-02-28";
-        # Commit hash for nixos-unstable as of 2021-02-28 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/f6b5bfdb470d60a876992749d0d708ed7b6b56ca.tar.gz;
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1rfsyz5axf2f7sc14wdm8dmb164xanbw7rcw6w127s0n6la17kq2";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
     };

--- a/postgres.nix
+++ b/postgres.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2020-05-08";
-        # Commit hash for nixos-unstable as of 2020-05-08 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/d78ba41a5604c8e06d40756a2436e52169354d36.tar.gz;
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "0bk81ddx1iq8i0nhg1i44kllihphyzhbc416zgylli0ycphknrkv";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
     };

--- a/scala.nix
+++ b/scala.nix
@@ -3,8 +3,8 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2020-09-26";
-        # Commit hash for nixos-unstable as of 2020-09-26 - get from head (git log)
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
         url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
         sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";

--- a/scala.nix
+++ b/scala.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
       overlays = [ (
@@ -18,7 +18,7 @@ let
       ) ];
     };
 
-  use-jdk = pkgs.jdk16;   # callPackage jdk/shared-jdk.nix { inherit jdk-name; inherit jdk-sha; };
+  use-jdk = pkgs.jdk17;   # callPackage jdk/shared-jdk.nix { inherit jdk-name; inherit jdk-sha; };
 in
   pkgs.stdenv.mkDerivation rec {
     name = "Scala";

--- a/scala.nix
+++ b/scala.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2020-05-08";
-        # Commit hash for nixos-unstable as of 2020-05-08 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/d78ba41a5604c8e06d40756a2436e52169354d36.tar.gz;
+        name = "nixos-unstable-2020-09-26";
+        # Commit hash for nixos-unstable as of 2020-09-26 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "0bk81ddx1iq8i0nhg1i44kllihphyzhbc416zgylli0ycphknrkv";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
       overlays = [ (
@@ -18,7 +18,7 @@ let
       ) ];
     };
 
-  use-jdk = pkgs.jdk14;   # callPackage jdk/shared-jdk.nix { inherit jdk-name; inherit jdk-sha; };
+  use-jdk = pkgs.jdk16;   # callPackage jdk/shared-jdk.nix { inherit jdk-name; inherit jdk-sha; };
 in
   pkgs.stdenv.mkDerivation rec {
     name = "Scala";

--- a/shell.nix
+++ b/shell.nix
@@ -21,9 +21,9 @@ in
       #pkgs.tmux
       pkgs.jq
       pkgs.tree
-      #pkgs.shellcheck
+      pkgs.shellcheck
       pkgs.watch
-      #pkgs.ripgrep
+      pkgs.ripgrep
       #pkgs.bat
       pkgs.fzf
       pkgs.fd

--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
     };

--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2020-05-08";
-        # Commit hash for nixos-unstable as of 2020-05-08 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/d78ba41a5604c8e06d40756a2436e52169354d36.tar.gz;
+        name = "nixos-unstable-2021-09-31";
+        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "0bk81ddx1iq8i0nhg1i44kllihphyzhbc416zgylli0ycphknrkv";
+        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
       }
     ) {
     };
@@ -18,13 +18,13 @@ in
     buildInputs = [
       #figlet
       pkgs.gettext
-      pkgs.tmux
+      #pkgs.tmux
       pkgs.jq
       pkgs.tree
-      pkgs.shellcheck
+      #pkgs.shellcheck
       pkgs.watch
-      pkgs.ripgrep
-      pkgs.bat
+      #pkgs.ripgrep
+      #pkgs.bat
       pkgs.fzf
       pkgs.fd
       pkgs.gron


### PR DESCRIPTION
Added kubectx for gcp
Updated to jdk17 for scala
Bumped nixos snapshot version to 2022-01-03 for aws, gcp, scala and shell

Tested locally on macOS Monterey
Pulled changes from leigh-perry/nix-setup repo